### PR TITLE
Updated the contact add function

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,7 +38,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 use Beepsend\Client;
 
 $client = new Client('userOrConnectionToken');
-$client->message->send(46736007518, 'BEEPSEND', 'Hello World! 你好世界!');
+$client->message->send('46736007518', 'BEEPSEND', 'Hello World! 你好世界!');
 ```
 
 ### Get customer data

--- a/src/Beepsend/Resource/Contact.php
+++ b/src/Beepsend/Resource/Contact.php
@@ -68,7 +68,7 @@ class Contact
      * @param int $groupId Contact group id
      * @return array
      */
-    public function add($msisdn, $firstName = null, $lastName = null, $groupId = null)
+    public function add($msisdn, $firstName = null, $lastName = null, $groups = null)
     {
         $data = array(
             'msisdn' => $msisdn
@@ -81,9 +81,19 @@ class Contact
         if (!is_null($lastName)) {
             $data['lastname'] = $lastName;
         }
-        
-        if (!is_null($groupId)) {
-            $data['group_id'] = $groupId;
+
+        if (!is_null($groups)) {
+            if (!is_array($groups)) {
+                throw new \InvalidArgumentException('groups must be an array of integers');
+            } else {
+                foreach($groups as $group) {
+                    if (!is_int($group)) {
+                        throw new \InvalidArgumentException('groups must be an array of integers.');
+                    } else {
+                        $data['groups'][] = array( 'id' => (int)$group);
+                    }
+                }
+            }
         }
         
         $response = $this->request->execute($this->actions['contacts'], 'POST', $data);


### PR DESCRIPTION
The update is that the SDK now supports adding multiple groups to a
newly created contact.

The SDK doesn't work at all with the API endpoint as it stands now, this
change fixes that by forcing the user to send in an array of integers
(the API uses an array of groups) or leave it unset or set it to null.

example:

$client->contact->add('46xxxxxxxxx', 'Jane', 'Doe', array( 123, 456, 789 ));
or
$client->contact->add('46xxxxxxxxx', 'Jane', 'Doe');