### PR TITLE
Adding Error Resource

### DIFF
--- a/src/Beepsend/Resource/Error.php
+++ b/src/Beepsend/Resource/Error.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Beepsend\Resource;
+
+use Beepsend\Request;
+
+/**
+ * Class Error
+ * @package Beepsend\Resource
+ */
+class Error
+{
+    /**
+     * Beepsend request handler
+     * @var \Beepsend\Request
+     */
+    private $request;
+
+    /**
+     * Actions to call
+     * @var array
+     */
+    private $actions = array(
+        'errors' => '/errors/'
+    );
+
+    /**
+     * Init error resource
+     * @param \Beepsend\Request $request
+     */
+    public function __construct(Request $request)
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * @param null $id
+     * @return array
+     */
+    public function get($id = null)
+    {
+        $url = $this->actions['errors'];
+
+        if ($id) {
+            $url .= (int)$id;
+        }
+
+        return $this->request->execute($url, 'GET');
+    }
+
+}


### PR DESCRIPTION
This PR adds support to the SDK for the `/errors/` endpoint.

Example usages:

Return a list of all error definitions
```
$client->error->get();
```

Return a single of error definition
```
$client->error->get(2);
```
