### PR TITLE
Expected array not string.

### DIFF
--- a/src/Beepsend/Resource/Message.php
+++ b/src/Beepsend/Resource/Message.php
@@ -91,11 +91,11 @@ class Message
             'encoding' => $encoding
         ];
         if (isset($options['label'])) {
-            $data = array_merge($data, $options['label']);
+            $data['label'] = $options['label'];
             unset($options['label']);
         }
         if (isset($options['send_time'])) {
-            $data = array_merge($data, $options['send_time']);
+            $data['send_time'] = $options['send_time'];
             unset($options['send_time']);
         }
         /* Merge additional options if we have */


### PR DESCRIPTION
This should expect a string as the key is already there "label" so it doesn't make much sense to write it like so when you build the query.

`$options = [
'label' = > ['label'=>'Mylabel']
];`